### PR TITLE
os.system calls migrated to subprocess.call / Popen api calls in Tools/mkdist.py

### DIFF
--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -139,7 +139,6 @@ run_command("find", dirname, "-name", "autom4te.cache", "-exec", "rm", "-rf", "{
 
 # Build documentation
 print("Building html documentation")
-# os.system("cd " + dirname + "/Doc/Manual && make all clean-baks") == 0 or failed()
 docpath = os.path.join(dirpath, "Doc", "Manual")
 run_command("make", "all", "clean-baks", cwd=docpath) == 0 or failed()
 

--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -8,6 +8,12 @@ def failed():
     print("mkdist.py failed to complete")
     sys.exit(2)
 
+def check_file_exists(path):
+    return os.path.isfile(path)
+
+def check_dir_exists(path):
+    return os.path.isdir(path)
+
 import argparse
 parser = argparse.ArgumentParser(description="Build a SWIG distribution tarball swig-x.y.z.tar.gz")
 parser.add_argument("version", help="version string in format x.y.z")
@@ -33,13 +39,18 @@ if dirname.lower() != dirname:
 
 # If directory and tarball exist, remove it
 print("Removing " + dirname)
-os.system("rm -rf " + dirname)
+if check_dir_exists(dirname):
+    subprocess.call(["rm", "-rf", dirname])
 
 print("Removing " + dirname + ".tar if exists")
-os.system("rm -f " + dirname + ".tar.gz")
+filename = dirname + ".tar"
+if check_file_exists(filename):
+    subprocess.call(["rm", "-rf", filename])
 
 print("Removing " + dirname + ".tar.gz if exists")
-os.system("rm -f " + dirname + ".tar")
+filename += ".gz"
+if check_file_exists(filename):
+    subprocess.call(["rm", "-rf", filename])
 
 # Grab the code from git
 

--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -24,7 +24,7 @@ def run_command(*args, **kwargs):
     """
     Runs an os command using subprocess module.
     """
-    return subprocess.call([*args], **kwargs)
+    return subprocess.call(args, **kwargs)
 
 import argparse
 parser = argparse.ArgumentParser(description="Build a SWIG distribution tarball swig-x.y.z.tar.gz")
@@ -116,7 +116,7 @@ print("Grabbing tagged release git repository using 'git archive' into " + outdi
 # using pipe operator without shell=True; split commands into individual ones.
 # git archive command
 command = ["git", "archive", "--prefix=" + outdir, tag, "."]
-archive_ps = subprocess.Popen((*command, ), cwd=rootdir, stdout=subprocess.PIPE)
+archive_ps = subprocess.Popen(command, cwd=rootdir, stdout=subprocess.PIPE)
 # tar -xf -
 tar_ps = subprocess.Popen(("tar", "-xf", "-"), stdin=archive_ps.stdout, stdout=subprocess.PIPE)
 archive_ps.stdout.close()  # Allow archive_ps to receive a SIGPIPE if tar_ps exits.

--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -9,10 +9,22 @@ def failed():
     sys.exit(2)
 
 def check_file_exists(path):
+    """
+    Checks if a file exists or not.
+    """
     return os.path.isfile(path)
 
 def check_dir_exists(path):
+    """
+    Checks if a folder exists or not.
+    """
     return os.path.isdir(path)
+
+def run_command(*args, **kwargs):
+    """
+    Runs an os command using subprocess module.
+    """
+    return subprocess.call([*args], **kwargs)
 
 import argparse
 parser = argparse.ArgumentParser(description="Build a SWIG distribution tarball swig-x.y.z.tar.gz")
@@ -28,6 +40,13 @@ dirname = "swig-" + version
 force_tag = args.force_tag
 skip_checks = args.skip_checks
 
+# Tools directory path $ENV/swig/Tools
+toolsdir = os.path.dirname(os.path.abspath(__file__))
+# Root directory path (swig) $ENV/swig
+rootdir = os.path.abspath(os.path.join(toolsdir, os.pardir))
+# version directory path $ENV/swig/<x.x.x>
+dirpath = os.path.join(rootdir, dirname)
+
 if sys.version_info[0:2] < (2, 7):
      print("Error: Python 2.7 or higher is required")
      sys.exit(3)
@@ -39,26 +58,26 @@ if dirname.lower() != dirname:
 
 # If directory and tarball exist, remove it
 print("Removing " + dirname)
-if check_dir_exists(dirname):
-    subprocess.call(["rm", "-rf", dirname])
+if check_dir_exists(dirpath):
+    run_command("rm", "-rf", dirpath)
 
 print("Removing " + dirname + ".tar if exists")
-filename = dirname + ".tar"
+filename = dirpath + ".tar"
 if check_file_exists(filename):
-    subprocess.call(["rm", "-rf", filename])
+    run_command("rm", "-rf", filename)
 
 print("Removing " + dirname + ".tar.gz if exists")
 filename += ".gz"
 if check_file_exists(filename):
-    subprocess.call(["rm", "-rf", filename])
+    run_command("rm", "-rf", filename)
 
 # Grab the code from git
 
 print("Checking there are no local changes in git repo")
-os.system("git remote update origin") == 0 or failed()
+run_command("git", "remote", "update", "origin") == 0 or failed()
 command = ["git", "status", "--porcelain", "-uno"]
 out = subprocess.check_output(command)
-if out.strip() != "":
+if out.strip():
     print("Local git repository has modifications")
     print(" ".join(command))
     print(out)
@@ -68,7 +87,7 @@ if not skip_checks:
     print("Checking git repository is in sync with remote repository")
     command = ["git", "log", "--oneline", branch + "..origin/" + branch]
     out = subprocess.check_output(command)
-    if out.strip() != "":
+    if out.strip():
         print("Remote repository has additional modifications to local repository")
         print(" ".join(command))
         print(out)
@@ -76,7 +95,7 @@ if not skip_checks:
 
     command = ["git", "log", "--oneline", "origin/" + branch + ".." + branch]
     out = subprocess.check_output(command)
-    if out.strip() != "":
+    if out.strip():
         print("Local repository has modifications not pushed to the remote repository")
         print("These should be pushed and checked that they pass Continuous Integration testing before continuing")
         print(" ".join(command))
@@ -84,31 +103,49 @@ if not skip_checks:
         sys.exit(3)
 
 print("Tagging release")
-tag = "'v" + version + "'"
+tag = "v" + version
 force = "-f " if force_tag else ""
-os.system("git tag -a -m 'Release version " + version + "' " + force + tag) == 0 or failed()
+command = ["git", "tag", "-a", "-m", "'Release version " + version + "'"]
+force and command.extend(force, tag)
+not force and command.append(tag)
+run_command(*command) == 0 or failed()
 
-outdir = os.path.basename(os.getcwd()) + "/" + dirname + "/"
+outdir = dirname + "/"
 print("Grabbing tagged release git repository using 'git archive' into " + outdir)
-os.system("(cd .. && git archive --prefix=" + outdir + " " + tag + " . | tar -xf -)") == 0 or failed()
+
+# using pipe operator without shell=True; split commands into individual ones.
+# git archive command
+command = ["git", "archive", "--prefix=" + outdir, tag, "."]
+archive_ps = subprocess.Popen((*command, ), cwd=rootdir, stdout=subprocess.PIPE)
+# tar -xf -
+tar_ps = subprocess.Popen(("tar", "-xf", "-"), stdin=archive_ps.stdout, stdout=subprocess.PIPE)
+archive_ps.stdout.close()  # Allow archive_ps to receive a SIGPIPE if tar_ps exits.
+output = tar_ps.communicate()
 
 # Go build the system
 
 print("Building system")
-os.system("cd " + dirname + " && ./autogen.sh") == 0 or failed()
-os.system("cd " + dirname + "/Source/CParse && bison -y -d parser.y && mv y.tab.c parser.c && mv y.tab.h parser.h") == 0 or failed()
-os.system("cd " + dirname + " && make -f Makefile.in libfiles srcdir=./") == 0 or failed()
+run_command("./autogen.sh", cwd=dirpath) == 0 or failed()
+
+cmdpath = os.path.join(dirpath, "Source", "CParse")
+run_command("bison", "-y", "-d", "parser.y", cwd=cmdpath) == 0 or failed()
+run_command("mv", "y.tab.c", "parser.c", cwd=cmdpath) == 0 or failed()
+run_command("mv", "y.tab.h", "parser.h", cwd=cmdpath) == 0 or failed()
+
+run_command("make", "-f", "Makefile.in", "libfiles", "srcdir=./", cwd=dirpath) == 0 or failed()
 
 # Remove autoconf files
-os.system("find " + dirname + " -name autom4te.cache -exec rm -rf {} \\;")
+run_command("find", dirname, "-name", "autom4te.cache", "-exec", "rm", "-rf", "{}", ";", cwd=rootdir)
 
 # Build documentation
 print("Building html documentation")
-os.system("cd " + dirname + "/Doc/Manual && make all clean-baks") == 0 or failed()
+# os.system("cd " + dirname + "/Doc/Manual && make all clean-baks") == 0 or failed()
+docpath = os.path.join(dirpath, "Doc", "Manual")
+run_command("make", "all", "clean-baks", cwd=docpath) == 0 or failed()
 
 # Build the tar-ball
-os.system("tar -cf " + dirname + ".tar " + dirname) == 0 or failed()
-os.system("gzip " + dirname + ".tar") == 0 or failed()
+run_command("tar", "-cf", dirname + ".tar", dirname, stdout=open(dirname + ".tar", "w")) == 0 or failed()
+run_command("gzip", dirname + ".tar", stdout=open(dirname + ".tar.gz", "w")) == 0 or failed()
 
 print("Finished building " + dirname + ".tar.gz")
 


### PR DESCRIPTION
### 📊 Metadata *

SWIG is a compiler that integrates C and C++ with languages including Perl, Python, Tcl, Ruby, PHP, Java, C#, D, Go, Lua, Octave, R, Scheme (Guile, MzScheme/Racket), Scilab, Ocaml. SWIG can also export its parse tree into XML. One of the python tools of swig include a mkdist.py script. This script takes in arguments and execute it without sanitation leading to Arbitrary code execution

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-swig/

### ⚙️ Description *

Mitigating the arbitrary code execution by total reworking rather than using more library code for sanitising. subprocess module provides a level of safety from code execution vulnerabilities. Also, changed the output directory of the build, maybe need some pointers on that.

### 💻 Technical Description *

Every call to "os.system" api is replaced by "subprocess.call/Popen" apis. subprocess module provides much more reliability for system command executions.

### 🐛 Proof of Concept (PoC) *

Run command, "python3 Tools/mkdist.py 'a; touch arbitrary-code-exec.pwn #"

Before fix
![image](https://user-images.githubusercontent.com/64132745/93142598-318e6200-f69b-11ea-84bf-822205b5e588.png)

### 🔥 Proof of Fix (PoF) *

After fix
![image](https://user-images.githubusercontent.com/64132745/93142784-8b8f2780-f69b-11ea-96f2-66dcc767ac75.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/93143020-f80a2680-f69b-11ea-93d7-56105f102a8e.png)

