### PR TITLE
Update: Missing escaping in maintainer scripts #1870

### DIFF
--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -27,8 +27,10 @@ skip_checks = args.skip_checks
 toolsdir = os.path.dirname(os.path.abspath(__file__))
 # Root directory path (swig) $ENV/swig
 rootdir = os.path.abspath(os.path.join(toolsdir, os.pardir))
+# current directory
+current_dir = os.getcwd()
 # version directory path $ENV/swig/<x.x.x>
-dirpath = os.path.join(toolsdir, dirname)
+dirpath = os.path.join(current_dir, dirname)
 
 if sys.version_info[0:2] < (2, 7):
      print("Error: Python 2.7 or higher is required")

--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -3,28 +3,11 @@
 import sys
 import os
 import subprocess
+from utils import *
 
 def failed():
     print("mkdist.py failed to complete")
     sys.exit(2)
-
-def check_file_exists(path):
-    """
-    Checks if a file exists or not.
-    """
-    return os.path.isfile(path)
-
-def check_dir_exists(path):
-    """
-    Checks if a folder exists or not.
-    """
-    return os.path.isdir(path)
-
-def run_command(*args, **kwargs):
-    """
-    Runs an os command using subprocess module.
-    """
-    return subprocess.call(args, **kwargs)
 
 import argparse
 parser = argparse.ArgumentParser(description="Build a SWIG distribution tarball swig-x.y.z.tar.gz")

--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -45,7 +45,7 @@ toolsdir = os.path.dirname(os.path.abspath(__file__))
 # Root directory path (swig) $ENV/swig
 rootdir = os.path.abspath(os.path.join(toolsdir, os.pardir))
 # version directory path $ENV/swig/<x.x.x>
-dirpath = os.path.join(rootdir, dirname)
+dirpath = os.path.join(toolsdir, dirname)
 
 if sys.version_info[0:2] < (2, 7):
      print("Error: Python 2.7 or higher is required")
@@ -125,6 +125,7 @@ output = tar_ps.communicate()
 # Go build the system
 
 print("Building system")
+run_command("mkdir", "-p", dirpath)
 run_command("./autogen.sh", cwd=dirpath) == 0 or failed()
 
 cmdpath = os.path.join(dirpath, "Source", "CParse")

--- a/Tools/mkrelease.py
+++ b/Tools/mkrelease.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+from utils import *
 
 def failed(message):
   if message == "":

--- a/Tools/mkrelease.py
+++ b/Tools/mkrelease.py
@@ -33,11 +33,12 @@ run_command("which", "rsync") and failed("rsync not installed/found. Please inst
 print("Making source tarball")
 force = "--force-tag" if force_tag else ""
 skip = "--skip-checks" if skip_checks else ""
-cmd = "python ./mkdist.py {} {} --branch {} {}".format(force, skip, branch, version)
-run_command(cmd.split()) and failed("")
+toolsdir = os.path.dirname(os.path.abspath(__file__))
+cmd = "python {}/mkdist.py {} {} --branch {} {}".format(toolsdir, force, skip, branch, version).split()
+run_command(*cmd) and failed("")
 
 print("Build Windows package")
-run_command("./mkwindows.sh", version) and failed("")
+run_command("{}/mkwindows.sh".format(toolsdir), version) and failed("")
 
 if username:
     print("Uploading to SourceForge")

--- a/Tools/mkrelease.py
+++ b/Tools/mkrelease.py
@@ -28,15 +28,16 @@ skip_checks = args.skip_checks
 username = args.username
 
 print("Looking for rsync")
-os.system("which rsync") and failed("rsync not installed/found. Please install.")
+run_command("which", "rsync") and failed("rsync not installed/found. Please install.")
 
 print("Making source tarball")
 force = "--force-tag" if force_tag else ""
 skip = "--skip-checks" if skip_checks else ""
-os.system("python ./mkdist.py {} {} --branch {} {}".format(force, skip, branch, version)) and failed("")
+cmd = "python ./mkdist.py {} {} --branch {} {}".format(force, skip, branch, version)
+run_command(cmd.split()) and failed("")
 
 print("Build Windows package")
-os.system("./mkwindows.sh " + version) and failed("")
+run_command("./mkwindows.sh", version) and failed("")
 
 if username:
     print("Uploading to SourceForge")
@@ -46,11 +47,11 @@ if username:
 
     # If a file with 'readme' in the name exists in the same folder as the zip/tarball, it gets automatically displayed as the release notes by SF
     full_readme_file = "readme-" + version + ".txt"
-    os.system("rm -f " + full_readme_file)
-    os.system("cat swig-" + version + "/README " + "swig-" + version + "/CHANGES.current " + "swig-" + version + "/RELEASENOTES " + "> " + full_readme_file)
+    run_command("rm", "-f", full_readme_file)
+    run_command("cat", "swig-" + version + "/README", "swig-" + version + "/CHANGES.current", "swig-" + version + "/RELEASENOTES", ">", full_readme_file)
 
-    os.system("rsync --archive --verbose -P --times -e ssh " + "swig-" + version + ".tar.gz " + full_readme_file + " " + swig_dir_sf) and failed("")
-    os.system("rsync --archive --verbose -P --times -e ssh " + "swigwin-" + version + ".zip " + full_readme_file + " " + swigwin_dir_sf) and failed("")
+    run_command("rsync", "--archive", "--verbose", "-P", "--times", "-e", "ssh", "swig-" + version + ".tar.gz", full_readme_file, swig_dir_sf) and failed("")
+    run_command("rsync", "--archive", "--verbose", "-P", "--times", "-e", "ssh", "swigwin-" + version + ".zip", full_readme_file, swigwin_dir_sf) and failed("")
 
     print("Finished")
 

--- a/Tools/utils.py
+++ b/Tools/utils.py
@@ -19,4 +19,8 @@ def run_command(*args, **kwargs):
     """
     Runs an os command using subprocess module.
     """
+    redirect_out = list(map(str.strip, " ".join(args).split(" > ")))
+    if len(redirect_out) > 1:
+        args, filepath = redirect_out[0].split(), redirect_out[-1]
+        kwargs.update(stdout=open(filepath, "w"))
     return subprocess.call(args, **kwargs)

--- a/Tools/utils.py
+++ b/Tools/utils.py
@@ -1,0 +1,22 @@
+import os, subprocess
+
+
+def check_file_exists(path):
+    """
+    Checks if a file exists or not.
+    """
+    return os.path.isfile(path)
+
+
+def check_dir_exists(path):
+    """
+    Checks if a folder exists or not.
+    """
+    return os.path.isdir(path)
+
+
+def run_command(*args, **kwargs):
+    """
+    Runs an os command using subprocess module.
+    """
+    return subprocess.call(args, **kwargs)


### PR DESCRIPTION
### 📊 Metadata *

https://huntr.dev/users/d3v53c has fixed the Remote Code Execution vulnerability 🔨.

#### Closed Bounty URL: https://github.com/swig/swig/pull/1870

#### PR URL: https://github.com/swig/swig/pull/1870

### ⚙️ Description *

This PR is an update to a merged fix to extend the scope of the previous fix to newly relevant files.

### 💻 Technical Description *

This fix includes migration of `os.system` apis to `subprocess.call` apis in order to better handle command executions without being susceptible to arbitrary code executions in the future.

### 👍 User Acceptance Testing (UAT)

After the fix the functionality is unaffected.

![image](https://user-images.githubusercontent.com/64132745/103087770-99dfce80-460e-11eb-9b83-3494656dfb11.png)

![image](https://user-images.githubusercontent.com/64132745/103087790-a95f1780-460e-11eb-85dc-80498f681593.png)


### 🔗 Relates to...

Related PR: https://github.com/swig/swig/pull/1870
